### PR TITLE
Update references to grblas

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Update env
         run: |
           conda install -q -c conda-forge python-graphblas dask pytest 'black=22.10' flake8 coverage coveralls scipy
-          pip install -e .
+          pip install -e . --no-deps
       - name: Lint with Black
         run: |
           black --version

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -46,7 +46,7 @@ jobs:
           python-version: 3.9
       - name: Update env
         run: |
-          conda install -q -c conda-forge 'graphblas>=6.1' grblas dask pytest 'black=22.10' flake8 coverage coveralls scipy
+          conda install -q -c conda-forge python-graphblas dask pytest 'black=22.10' flake8 coverage coveralls scipy
           pip install -e .
       - name: Lint with Black
         run: |

--- a/dask_grblas/__init__.py
+++ b/dask_grblas/__init__.py
@@ -1,5 +1,5 @@
-import grblas.mask
-from grblas import replace  # noqa
+import graphblas.core.mask
+from graphblas import replace  # noqa
 
 from . import _version, mask, scalar, utils, vector, ss  # noqa
 from .construction import column_stack, concat_vectors, row_stack  # noqa
@@ -10,13 +10,13 @@ from .vector import Vector
 from . import matrix  # isort:skip (here to avoid cyclic imports)
 
 for dgb_type, inner_type, gb_type in [
-    (mask.StructuralMask, None, grblas.mask.StructuralMask),
-    (mask.ValueMask, None, grblas.mask.ValueMask),
-    (mask.ComplementedStructuralMask, None, grblas.mask.ComplementedStructuralMask),
-    (mask.ComplementedValueMask, None, grblas.mask.ComplementedValueMask),
-    (Scalar, scalar.InnerScalar, grblas.Scalar),
-    (Vector, vector.InnerVector, grblas.Vector),
-    (Matrix, matrix.InnerMatrix, grblas.Matrix),
+    (mask.StructuralMask, None, graphblas.core.mask.StructuralMask),
+    (mask.ValueMask, None, graphblas.core.mask.ValueMask),
+    (mask.ComplementedStructuralMask, None, graphblas.core.mask.ComplementedStructuralMask),
+    (mask.ComplementedValueMask, None, graphblas.core.mask.ComplementedValueMask),
+    (Scalar, scalar.InnerScalar, graphblas.Scalar),
+    (Vector, vector.InnerVector, graphblas.Vector),
+    (Matrix, matrix.InnerMatrix, graphblas.Matrix),
 ]:
     utils._grblas_types[dgb_type] = gb_type
     utils._grblas_types[gb_type] = gb_type

--- a/dask_grblas/base.py
+++ b/dask_grblas/base.py
@@ -1,14 +1,15 @@
 from numbers import Number
 import dask.array as da
-import grblas as gb
+import graphblas as gb
 import numpy as np
-from grblas.operator import UNKNOWN_OPCLASS, find_opclass, get_typed_op
+import graphblas.core.base
+from graphblas.core.operator import UNKNOWN_OPCLASS, find_opclass, get_typed_op
 
 from . import replace as replace_singleton
 from .mask import Mask
 from .utils import get_grblas_type, get_meta, np_dtype, wrap_inner
 
-_expect_type = gb.base._expect_type
+_expect_type = gb.core.base._expect_type
 
 
 def _check_mask(mask, output=None):
@@ -113,7 +114,7 @@ class BaseType:
         if mask is not None:
             if not isinstance(mask, Mask):
                 self._meta.dup(dtype=dtype, mask=mask, name=name)  # should raise
-                raise TypeError("Use dask_grblas mask, not a mask from grblas")
+                raise TypeError("Use dask_grblas mask, not a mask from graphblas")
             meta = self._meta.dup(dtype=dtype, mask=mask._meta, name=name)
         else:
             meta = self._meta.dup(dtype=dtype, name=name)
@@ -176,16 +177,16 @@ class BaseType:
                 accum = accum.binaryop
         return Updater(self, mask=mask, accum=accum, replace=replace, input_mask=input_mask)
 
-    __array__ = gb.base.BaseType.__array__
-    __bool__ = gb.base.BaseType.__bool__
+    __array__ = gb.core.base.BaseType.__array__
+    __bool__ = gb.core.base.BaseType.__bool__
     # TODO: get these to work so we can do things like `gb.op.plus(v | w)`
-    __or__ = gb.base.BaseType.__or__
-    __ror__ = gb.base.BaseType.__ror__
-    __and__ = gb.base.BaseType.__and__
-    __rand__ = gb.base.BaseType.__rand__
-    __matmul__ = gb.base.BaseType.__matmul__
-    __rmatmul__ = gb.base.BaseType.__rmatmul__
-    __imatmul__ = gb.base.BaseType.__imatmul__
+    __or__ = gb.core.base.BaseType.__or__
+    __ror__ = gb.core.base.BaseType.__ror__
+    __and__ = gb.core.base.BaseType.__and__
+    __rand__ = gb.core.base.BaseType.__rand__
+    __matmul__ = gb.core.base.BaseType.__matmul__
+    __rmatmul__ = gb.core.base.BaseType.__rmatmul__
+    __imatmul__ = gb.core.base.BaseType.__imatmul__
 
     def _optional_dup(self):
         # TODO: maybe try to create an optimization pass that remove these if they are unnecessary

--- a/dask_grblas/io.py
+++ b/dask_grblas/io.py
@@ -2,7 +2,7 @@ import os
 
 from math import floor, sqrt
 from numpy import asarray, conj, zeros, concatenate, ones, empty
-from scipy.io import mmio  # noqa
+from scipy.io import _mmio as mmio  # noqa
 
 
 def symm_I_J(pos, n):
@@ -120,7 +120,7 @@ def mmread(source, *, dup_op=None, name=None, row_begin=0, row_end=None, col_beg
     )
     if isinstance(array, coo_matrix):
         nrows, ncols = array.shape
-        return Matrix.from_values(
+        return Matrix.from_coo(
             array.row, array.col, array.data, nrows=nrows, ncols=ncols, dup_op=dup_op, name=name
         )
     # SS, SuiteSparse-specific: import_full

--- a/dask_grblas/matrix.py
+++ b/dask_grblas/matrix.py
@@ -1134,9 +1134,7 @@ def _concat_matrix(seq, axis=0):
         if len(ncols) == 1:
             (ncols,) = ncols
             seq = [
-                InnerMatrix(
-                    gb.Matrix(dtype=item.value.dtype, nrows=item.value.nrows, ncols=ncols)
-                )
+                InnerMatrix(gb.Matrix(dtype=item.value.dtype, nrows=item.value.nrows, ncols=ncols))
                 if item.value.ncols == 0
                 else item
                 for item in seq
@@ -1149,9 +1147,7 @@ def _concat_matrix(seq, axis=0):
         if len(nrows) == 1:
             (nrows,) = nrows
             seq = [
-                InnerMatrix(
-                    gb.Matrix(dtype=item.value.dtype, nrows=nrows, ncols=item.value.ncols)
-                )
+                InnerMatrix(gb.Matrix(dtype=item.value.dtype, nrows=nrows, ncols=item.value.ncols))
                 if item.value.nrows == 0
                 else item
                 for item in seq

--- a/dask_grblas/matrix.py
+++ b/dask_grblas/matrix.py
@@ -1,11 +1,11 @@
 import dask.array as da
 import numpy as np
-import grblas as gb
+import graphblas as gb
 from dask.base import tokenize
 from dask.delayed import Delayed, delayed
 from dask.highlevelgraph import HighLevelGraph
-from grblas import binary, monoid, semiring
-from grblas.dtypes import lookup_dtype
+from graphblas import binary, monoid, semiring
+from graphblas.dtypes import lookup_dtype
 
 from .base import BaseType, InnerBaseType
 from .base import _nvals as _nvals_in_chunk
@@ -27,11 +27,11 @@ from .utils import (
 class InnerMatrix(InnerBaseType):
     ndim = 2
 
-    def __init__(self, grblas_matrix):
-        assert type(grblas_matrix) is gb.Matrix
-        self.value = grblas_matrix
-        self.shape = grblas_matrix.shape
-        self.dtype = np_dtype(grblas_matrix.dtype)
+    def __init__(self, graphblas_matrix):
+        assert type(graphblas_matrix) is gb.Matrix
+        self.value = graphblas_matrix
+        self.shape = graphblas_matrix.shape
+        self.dtype = np_dtype(graphblas_matrix.dtype)
 
     def __getitem__(self, index):
         # This always copies!
@@ -50,7 +50,7 @@ class Matrix(BaseType):
         if not isinstance(matrix, Delayed):
             raise TypeError(
                 "Value is not a dask delayed object.  "
-                "Please use dask.delayed to create a grblas.Matrix"
+                "Please use dask.delayed to create a graphblas.Matrix"
             )
         inner = delayed(InnerMatrix)(matrix)
         value = da.from_delayed(inner, (nrows, ncols), dtype=np_dtype(dtype), name=name)
@@ -59,7 +59,7 @@ class Matrix(BaseType):
     @classmethod
     def from_matrix(cls, matrix, chunks=None, *, name=None):
         if not isinstance(matrix, gb.Matrix):
-            raise TypeError("Value is not a grblas.Matrix")
+            raise TypeError("Value is not a graphblas.Matrix")
         if chunks is not None:
             raise NotImplementedError()
         return cls.from_delayed(delayed(matrix), matrix.dtype, *matrix.shape, name=name)
@@ -149,9 +149,9 @@ class Matrix(BaseType):
                 nrows = implied_nrows if nrows is None else nrows
                 ncols = implied_ncols if ncols is None else ncols
 
-            idtype = gb.Matrix.new(rows.dtype).dtype
+            idtype = gb.Matrix(rows.dtype).dtype
             np_idtype_ = np_dtype(idtype)
-            vdtype = gb.Matrix.new(values.dtype).dtype
+            vdtype = gb.Matrix(values.dtype).dtype
             np_vdtype_ = np_dtype(vdtype)
 
             chunks = da.core.normalize_chunks(chunks, (nrows, ncols), dtype=np_idtype_)
@@ -172,7 +172,7 @@ class Matrix(BaseType):
                 dtype=np_idtype_,
                 meta=np.array([]),
             )
-            meta = InnerMatrix(gb.Matrix.new(vdtype))
+            meta = InnerMatrix(gb.Matrix(vdtype))
             delayed = da.core.blockwise(
                 *(_from_values2D, "ij"),
                 *(fragments, "ijk"),
@@ -196,7 +196,7 @@ class Matrix(BaseType):
     def new(cls, dtype, nrows=0, ncols=0, *, chunks="auto", name=None):
         dtype = dtype.lower() if isinstance(dtype, str) else dtype
         if nrows == 0 and ncols == 0:
-            matrix = gb.Matrix.new(dtype, nrows, ncols)
+            matrix = gb.Matrix(dtype, nrows, ncols)
             return cls.from_delayed(
                 delayed(matrix), matrix.dtype, matrix.nrows, matrix.ncols, nvals=0, name=name
             )
@@ -209,7 +209,7 @@ class Matrix(BaseType):
             row_ranges = build_ranges_dask_array_from_chunks(chunks[0], rname)
             col_ranges = build_ranges_dask_array_from_chunks(chunks[1], cname)
 
-            meta = InnerMatrix(gb.Matrix.new(dtype))
+            meta = InnerMatrix(gb.Matrix(dtype))
             try:
                 np_dtype_ = np_dtype(dtype)
             except AttributeError:
@@ -238,7 +238,7 @@ class Matrix(BaseType):
         assert delayed.ndim == 2
         self._delayed = delayed
         if meta is None:
-            meta = gb.Matrix.new(delayed.dtype, *delayed.shape)
+            meta = gb.Matrix(delayed.dtype, *delayed.shape)
         self._meta = meta
         self._nrows = meta.nrows
         self._ncols = meta.ncols
@@ -318,7 +318,7 @@ class Matrix(BaseType):
         len_kdiag = kdiag_row_stop - kdiag_row_start
 
         gb_dtype = self.dtype if dtype is None else lookup_dtype(dtype)
-        meta = wrap_inner(gb.Vector.new(gb_dtype))
+        meta = wrap_inner(gb.Vector(gb_dtype))
         if len_kdiag <= 0:
             return get_return_type(meta).new(gb_dtype)
 
@@ -380,9 +380,9 @@ class Matrix(BaseType):
         len_kdiag = kdiag_row_stop - kdiag_row_start
 
         gb_dtype = self.dtype if dtype is None else lookup_dtype(dtype)
-        meta = gb.Vector.new(gb_dtype)
+        meta = gb.Vector(gb_dtype)
         if len_kdiag <= 0:
-            return get_return_type(meta).new(gb_dtype)
+            return get_return_type(meta)(gb_dtype)
 
         chunks = da.core.normalize_chunks(chunks, (len_kdiag,), dtype=np.int64)
         output_indx_ranges = build_ranges_dask_array_from_chunks(chunks[0], "output_indx_ranges-")
@@ -470,9 +470,9 @@ class Matrix(BaseType):
         right_meta = right
 
         if type(left) is Scalar:
-            left_meta = left.dtype.np_type(0)
+            left_meta = left.dtype.np_type.type(0)
         if type(right) is Scalar:
-            right_meta = right.dtype.np_type(0)
+            right_meta = right.dtype.np_type.type(0)
 
         meta = self._meta.apply(op=op, left=left_meta, right=right_meta)
         return GbDelayed(self, "apply", op, right, meta=meta, left=left)
@@ -534,9 +534,9 @@ class Matrix(BaseType):
         if type(values) is list:
             values = da.core.from_array(np.array(values), name="values-" + tokenize(values))
 
-        idtype = gb.Matrix.new(rows.dtype).dtype
+        idtype = gb.Matrix(rows.dtype).dtype
         np_idtype_ = np_dtype(idtype)
-        vdtype = gb.Matrix.new(values.dtype).dtype
+        vdtype = gb.Matrix(values.dtype).dtype
         np_vdtype_ = np_dtype(vdtype)
 
         rname = "-row-ranges" + tokenize(x, x.chunks[0])
@@ -553,7 +553,7 @@ class Matrix(BaseType):
             dtype=np_idtype_,
             meta=np.array([]),
         )
-        meta = InnerMatrix(gb.Matrix.new(vdtype))
+        meta = InnerMatrix(gb.Matrix(vdtype))
         delayed = da.core.blockwise(
             *(_build_2D_chunk, "ij"),
             *(x, "ij"),
@@ -676,7 +676,7 @@ class Matrix(BaseType):
         self.__init__(deleted)
 
 
-Matrix.ss = gb.utils.class_property(Matrix.ss, ss)
+Matrix.ss = gb.core.utils.class_property(Matrix.ss, ss)
 
 
 class TransposedMatrix:
@@ -818,9 +818,9 @@ def _chunk_diag(
                 chunk_kdiag_col_start:chunk_kdiag_col_stop,
             ]
             # extract its diagonal
-            vector = gb.ss.diag(matrix.new(), k=0, dtype=gb_dtype)
+            vector = gb.ss.diag(matrix(), k=0, dtype=gb_dtype)
             return wrap_inner(vector)
-    return wrap_inner(gb.Vector.new(gb_dtype))
+    return wrap_inner(gb.Vector(gb_dtype))
 
 
 def _resize(
@@ -941,7 +941,7 @@ def _new_Matrix_chunk(out_row_range, out_col_range, gb_dtype=None):
     """
     nrows = out_row_range[0].stop - out_row_range[0].start
     ncols = out_col_range[0].stop - out_col_range[0].start
-    return InnerMatrix(gb.Matrix.new(gb_dtype, nrows=nrows, ncols=ncols))
+    return InnerMatrix(gb.Matrix(gb_dtype, nrows=nrows, ncols=ncols))
 
 
 def _from_values2D(fragments, out_row_range, out_col_range, gb_dtype=None):
@@ -957,7 +957,7 @@ def _from_values2D(fragments, out_row_range, out_col_range, gb_dtype=None):
     nrows = out_row_range[0].stop - out_row_range[0].start
     ncols = out_col_range[0].stop - out_col_range[0].start
     return InnerMatrix(
-        gb.Matrix.from_values(rows, cols, vals, nrows=nrows, ncols=ncols, dtype=gb_dtype)
+        gb.Matrix.from_coo(rows, cols, vals, nrows=nrows, ncols=ncols, dtype=gb_dtype)
     )
 
 
@@ -1135,7 +1135,7 @@ def _concat_matrix(seq, axis=0):
             (ncols,) = ncols
             seq = [
                 InnerMatrix(
-                    gb.Matrix.new(dtype=item.value.dtype, nrows=item.value.nrows, ncols=ncols)
+                    gb.Matrix(dtype=item.value.dtype, nrows=item.value.nrows, ncols=ncols)
                 )
                 if item.value.ncols == 0
                 else item
@@ -1150,7 +1150,7 @@ def _concat_matrix(seq, axis=0):
             (nrows,) = nrows
             seq = [
                 InnerMatrix(
-                    gb.Matrix.new(dtype=item.value.dtype, nrows=nrows, ncols=item.value.ncols)
+                    gb.Matrix(dtype=item.value.dtype, nrows=nrows, ncols=item.value.ncols)
                 )
                 if item.value.nrows == 0
                 else item
@@ -1160,5 +1160,5 @@ def _concat_matrix(seq, axis=0):
     return InnerMatrix(value)
 
 
-gb.utils._output_types[Matrix] = gb.Matrix
-gb.utils._output_types[TransposedMatrix] = gb.matrix.TransposedMatrix
+gb.core.utils._output_types[Matrix] = gb.Matrix
+gb.core.utils._output_types[TransposedMatrix] = gb.core.matrix.TransposedMatrix

--- a/dask_grblas/scalar.py
+++ b/dask_grblas/scalar.py
@@ -1,5 +1,5 @@
 import dask.array as da
-import grblas as gb
+import graphblas as gb
 import numpy as np
 from dask.delayed import Delayed, delayed
 
@@ -11,7 +11,7 @@ from .utils import get_meta, np_dtype
 def from_delayed(cls, scalar, dtype, *, name=None):
     if not isinstance(scalar, Delayed):
         raise TypeError(
-            "Value is not a dask delayed object.  Please use dask.delayed to create a grblas.Scalar"
+            "Value is not a dask delayed object.  Please use dask.delayed to create a graphblas.Scalar"
         )
     inner = delayed(InnerScalar)(scalar)
     value = da.from_delayed(inner, (), dtype=np_dtype(dtype), name=name)
@@ -36,7 +36,7 @@ def from_value(cls, scalar, dtype=None, *, name=None):
 
 
 def new(cls, dtype, *, name=None):
-    scalar = gb.Scalar.new(dtype)
+    scalar = gb.Scalar(dtype)
     return cls.from_delayed(delayed(scalar), scalar.dtype, name=name)
 
 
@@ -44,9 +44,9 @@ class InnerScalar(InnerBaseType):
     ndim = 0
     shape = ()
 
-    def __init__(self, grblas_scalar):
-        self.value = grblas_scalar
-        self.dtype = np_dtype(grblas_scalar.dtype)
+    def __init__(self, graphblas_scalar):
+        self.value = graphblas_scalar
+        self.dtype = np_dtype(graphblas_scalar.dtype)
 
 
 class Scalar(BaseType):
@@ -71,7 +71,7 @@ class Scalar(BaseType):
         assert delayed.ndim == 0
         self._delayed = delayed
         if meta is None:
-            meta = gb.Scalar.new(delayed.dtype)
+            meta = gb.Scalar(delayed.dtype)
         self._meta = meta
         self.dtype = meta.dtype
 
@@ -187,7 +187,7 @@ class Scalar(BaseType):
         """
         from .vector import Vector
 
-        rv = Vector.new(self.dtype, size=1)
+        rv = Vector(self.dtype, size=1)
         if not self.is_empty:
             rv[0] = self
         return rv
@@ -248,5 +248,5 @@ def _invert(x):
     return InnerScalar(~x.value)
 
 
-gb.utils._output_types[Scalar] = gb.Scalar
-gb.utils._output_types[PythonScalar] = gb.Scalar
+gb.core.utils._output_types[Scalar] = gb.Scalar
+gb.core.utils._output_types[PythonScalar] = gb.Scalar

--- a/dask_grblas/scalar.py
+++ b/dask_grblas/scalar.py
@@ -11,7 +11,8 @@ from .utils import get_meta, np_dtype
 def from_delayed(cls, scalar, dtype, *, name=None):
     if not isinstance(scalar, Delayed):
         raise TypeError(
-            "Value is not a dask delayed object.  Please use dask.delayed to create a graphblas.Scalar"
+            "Value is not a dask delayed object.  "
+            "Please use dask.delayed to create a graphblas.Scalar"
         )
     inner = delayed(InnerScalar)(scalar)
     value = da.from_delayed(inner, (), dtype=np_dtype(dtype), name=name)

--- a/dask_grblas/ss/_core.py
+++ b/dask_grblas/ss/_core.py
@@ -1,4 +1,4 @@
-from grblas.base import _expect_type
+from graphblas.core.base import _expect_type
 from ..matrix import Matrix, TransposedMatrix
 from ..scalar import Scalar
 from ..vector import Vector

--- a/dask_grblas/vector.py
+++ b/dask_grblas/vector.py
@@ -709,9 +709,7 @@ def _resize(output_range, inner_vector, index_range, old_size, new_size):
             return InnerVector(inner_vector.value[start:stop].new())
     elif index_range[0].stop == old_size and old_size <= output_range[0].start:
         return InnerVector(
-            gb.Vector(
-                dtype=inner_vector.dtype, size=output_range[0].stop - output_range[0].start
-            )
+            gb.Vector(dtype=inner_vector.dtype, size=output_range[0].stop - output_range[0].start)
         )
     else:
         return InnerVector(gb.Vector(inner_vector.dtype, size=0))

--- a/dask_grblas/vector.py
+++ b/dask_grblas/vector.py
@@ -1,10 +1,10 @@
 import dask.array as da
 import numpy as np
-import grblas as gb
+import graphblas as gb
 from dask.base import tokenize
 from dask.delayed import Delayed, delayed
-from grblas import binary, monoid, semiring
-from grblas.dtypes import lookup_dtype
+from graphblas import binary, monoid, semiring
+from graphblas.dtypes import lookup_dtype
 
 from .base import BaseType, InnerBaseType, _nvals
 from .expr import AmbiguousAssignOrExtract, GbDelayed, Updater, Assigner
@@ -23,12 +23,12 @@ from .utils import (
 class InnerVector(InnerBaseType):
     ndim = 1
 
-    def __init__(self, grblas_vector):
-        assert type(grblas_vector) is gb.Vector
-        self.value = grblas_vector
-        self.size = grblas_vector.size
-        self.shape = grblas_vector.shape
-        self.dtype = np_dtype(grblas_vector.dtype)
+    def __init__(self, graphblas_vector):
+        assert type(graphblas_vector) is gb.Vector
+        self.value = graphblas_vector
+        self.size = graphblas_vector.size
+        self.shape = graphblas_vector.shape
+        self.dtype = np_dtype(graphblas_vector.dtype)
 
     def __getitem__(self, index):
         # This always copies!
@@ -46,12 +46,12 @@ class InnerVector(InnerBaseType):
                     return InnerVector(value)
                 elif type(index) is slice and index == slice(None):
                     # [None, :]
-                    matrix_value = gb.Matrix.new(self.value.dtype, 1, self.value.size)
+                    matrix_value = gb.Matrix(self.value.dtype, 1, self.value.size)
                     matrix_value[0, :] = self.value
                 else:
                     # [None, :5], [None, [1, 2]], etc
                     value = self.value[index].new()
-                    matrix_value = gb.Matrix.new(self.value.dtype, 1, value.size)
+                    matrix_value = gb.Matrix(self.value.dtype, 1, value.size)
                     matrix_value[0, :] = value
                 return InnerMatrix(matrix_value)
             elif index[1] is None:
@@ -63,12 +63,12 @@ class InnerVector(InnerBaseType):
                 elif type(index) is slice and index == slice(None):
                     # [:, None]
                     # matrix_value = self.value._as_matrix()  # TODO: grblas >=1.3.15
-                    matrix_value = gb.Matrix.new(self.value.dtype, self.value.size, 1)
+                    matrix_value = gb.Matrix(self.value.dtype, self.value.size, 1)
                     matrix_value[:, 0] = self.value
                 else:
                     # [:5, None], [[1, 2], None], etc
                     value = self.value[index].new()
-                    matrix_value = gb.Matrix.new(self.value.dtype, value.size, 1)
+                    matrix_value = gb.Matrix(self.value.dtype, value.size, 1)
                     matrix_value[:, 0] = value
                 return InnerMatrix(matrix_value)
         raise IndexError(f"Too many indices for vector: {index}")
@@ -83,7 +83,7 @@ class Vector(BaseType):
         if not isinstance(vector, Delayed):
             raise TypeError(
                 "Value is not a dask delayed object.  "
-                "Please use dask.delayed to create a grblas.Vector"
+                "Please use dask.delayed to create a graphblas.Vector"
             )
         inner = delayed(InnerVector)(vector)
         value = da.from_delayed(inner, (size,), dtype=np_dtype(dtype), name=name)
@@ -92,7 +92,7 @@ class Vector(BaseType):
     @classmethod
     def from_vector(cls, vector, *, chunks=None, name=None):
         if not isinstance(vector, gb.Vector):
-            raise TypeError("Value is not a grblas.Vector")
+            raise TypeError("Value is not a graphblas.Vector")
         if chunks is not None:
             raise NotImplementedError()
         return cls.from_delayed(delayed(vector), vector.dtype, vector.size, name=name)
@@ -125,9 +125,9 @@ class Vector(BaseType):
                     raise Exception()
                 size = implied_size if size is None else size
 
-            idtype = gb.Vector.new(indices.dtype).dtype
+            idtype = gb.Vector(indices.dtype).dtype
             np_idtype_ = np_dtype(idtype)
-            vdtype = gb.Vector.new(values.dtype).dtype
+            vdtype = gb.Vector(values.dtype).dtype
             np_vdtype_ = np_dtype(vdtype)
             chunks = da.core.normalize_chunks(chunks, (size,), dtype=np_idtype_)
             name_ = name
@@ -142,7 +142,7 @@ class Vector(BaseType):
                 dtype=np_vdtype_,
                 meta=np.array([]),
             )
-            meta = InnerVector(gb.Vector.new(vdtype))
+            meta = InnerVector(gb.Vector(vdtype))
             delayed = da.core.blockwise(
                 *(_from_values1D, "i"),
                 *(fragments, "ij"),
@@ -156,14 +156,14 @@ class Vector(BaseType):
             return Vector(delayed)
 
         chunks = None
-        vector = gb.Vector.from_values(indices, values, size=size, dup_op=dup_op, dtype=dtype)
+        vector = gb.Vector.from_coo(indices, values, size=size, dup_op=dup_op, dtype=dtype)
         return cls.from_vector(vector, chunks=chunks, name=name)
 
     @classmethod
     def new(cls, dtype, size=0, *, chunks="auto", name=None):
         if size > 0:
             chunks = da.core.normalize_chunks(chunks, (size,), dtype=int)
-            meta = gb.Vector.new(dtype)
+            meta = gb.Vector(dtype)
             vdtype = meta.dtype
             np_vdtype_ = np_dtype(vdtype)
             chunksz = build_ranges_dask_array_from_chunks(chunks[0], "ranges-" + tokenize(chunks))
@@ -176,7 +176,7 @@ class Vector(BaseType):
             )
             return Vector(delayed_, nvals=0)
 
-        vector = gb.Vector.new(dtype, size)
+        vector = gb.Vector(dtype, size)
         return cls.from_delayed(delayed(vector), vector.dtype, vector.size, nvals=0, name=name)
 
     def __init__(self, delayed, meta=None, nvals=None):
@@ -191,7 +191,7 @@ class Vector(BaseType):
         assert delayed.ndim == 1
         self._delayed = delayed
         if meta is None:
-            meta = gb.Vector.new(delayed.dtype, delayed.shape[0])
+            meta = gb.Vector(delayed.dtype, delayed.shape[0])
         self._meta = meta
         self._size = meta.size
         self.dtype = meta.dtype
@@ -213,7 +213,7 @@ class Vector(BaseType):
             chunks=(x.chunks[0], (1,)),
             new_axis=1,
             dtype=x.dtype,
-            meta=InnerMatrix(gb.Matrix.new(self.dtype)),
+            meta=InnerMatrix(gb.Matrix(self.dtype)),
         )
         return Matrix(x)
 
@@ -297,7 +297,7 @@ class Vector(BaseType):
             dtype=dtype,
             meta=np.array([[[]]]),
         )
-        meta = gb.Matrix.new(gb_dtype)
+        meta = gb.Matrix(gb_dtype)
         delayed = da.reduction(
             fragments,
             _identity,
@@ -318,7 +318,7 @@ class Vector(BaseType):
             return self.resize(*self.shape, chunks=chunks, inplace=False)
         # chunks = da.core.normalize_chunks(chunks, self.shape, dtype=np.int64)
         # id = self.to_values()
-        # new = Vector.from_values(*id, *self.shape, trust_size=True, chunks=chunks)
+        # new = Vector.from_coo(*id, *self.shape, trust_size=True, chunks=chunks)
         # if inplace:
         #     self.__init__(new._delayed)
         # else:
@@ -434,9 +434,9 @@ class Vector(BaseType):
         right_meta = right
 
         if type(left) is Scalar:
-            left_meta = left.dtype.np_type(0)
+            left_meta = left.dtype.np_type.type(0)
         if type(right) is Scalar:
-            right_meta = right.dtype.np_type(0)
+            right_meta = right.dtype.np_type.type(0)
 
         meta = self._meta.apply(op=op, left=left_meta, right=right_meta)
         return GbDelayed(self, "apply", op, right, meta=meta, left=left)
@@ -469,9 +469,9 @@ class Vector(BaseType):
         if type(values) is list:
             values = da.core.from_array(np.array(values), name="values-" + tokenize(values))
 
-        idtype = gb.Matrix.new(indices.dtype).dtype
+        idtype = gb.Matrix(indices.dtype).dtype
         np_idtype_ = np_dtype(idtype)
-        vdtype = gb.Matrix.new(values.dtype).dtype
+        vdtype = gb.Matrix(values.dtype).dtype
         np_vdtype_ = np_dtype(vdtype)
 
         iname = "-index-ranges" + tokenize(x, x.chunks[0])
@@ -484,7 +484,7 @@ class Vector(BaseType):
             dtype=np_idtype_,
             meta=np.array([[]]),
         )
-        meta = InnerVector(gb.Vector.new(vdtype))
+        meta = InnerVector(gb.Vector(vdtype))
         delayed = da.core.blockwise(
             *(_build_1D_chunk, "i"),
             *(x, "i"),
@@ -499,7 +499,7 @@ class Vector(BaseType):
         # # This doesn't do anything special yet.  Should we have name= and chunks= keywords?
         # # TODO: raise if output is not empty
         # # This operation could, perhaps, partition indices and values if there are chunks
-        # vector = gb.Vector.new(self.dtype, size=self.size)
+        # vector = gb.Vector(self.dtype, size=self.size)
         # vector.build(indices, values, dup_op=dup_op)
         # self.__init__(Vector.from_vector(vector)._delayed)
 
@@ -589,7 +589,7 @@ class Vector(BaseType):
         # return self.gb_obj[0]
 
 
-Vector.ss = gb.utils.class_property(Vector.ss, ss)
+Vector.ss = gb.core.utils.class_property(Vector.ss, ss)
 
 
 def _chunk_diag(
@@ -648,7 +648,7 @@ def _chunk_diag(
             out_col_stop_ = max(cols.stop, out_col_stop_)
 
         ncols = out_col_stop_ - out_col_start
-        matrix = gb.Matrix.new(gb_dtype, nrows=nrows, ncols=ncols)
+        matrix = gb.Matrix(gb_dtype, nrows=nrows, ncols=ncols)
 
         # return empty matrix if k-diagonal does not touch it
         if rows.stop <= kdiag_nt_out_col_start or kdiag_nt_out_col_stop_ <= rows.start:
@@ -685,7 +685,7 @@ def _chunk_diag(
     if vec_chunk.stop == kdiag_size:
         if cols.start >= kdiag_col_stop_:
             width = ncols
-    matrix = gb.Matrix.new(gb_dtype, nrows=nrows, ncols=width)
+    matrix = gb.Matrix(gb_dtype, nrows=nrows, ncols=width)
     return wrap_inner(matrix)
 
 
@@ -709,12 +709,12 @@ def _resize(output_range, inner_vector, index_range, old_size, new_size):
             return InnerVector(inner_vector.value[start:stop].new())
     elif index_range[0].stop == old_size and old_size <= output_range[0].start:
         return InnerVector(
-            gb.Vector.new(
+            gb.Vector(
                 dtype=inner_vector.dtype, size=output_range[0].stop - output_range[0].start
             )
         )
     else:
-        return InnerVector(gb.Vector.new(inner_vector.dtype, size=0))
+        return InnerVector(gb.Vector(inner_vector.dtype, size=0))
 
 
 def _as_matrix(x):
@@ -730,7 +730,7 @@ def _delitem_chunk(inner_vec, chunk_range, index):
 
 
 def _new_Vector_chunk(chunk_range, gb_dtype):
-    return InnerVector(gb.Vector.new(gb_dtype, size=chunk_range[0].stop - chunk_range[0].start))
+    return InnerVector(gb.Vector(gb_dtype, size=chunk_range[0].stop - chunk_range[0].start))
 
 
 def _build_1D_chunk(inner_vector, out_index_range, fragments, dup_op=None):
@@ -751,7 +751,7 @@ def _from_values1D(fragments, index_range, gb_dtype=None):
     inds = np.concatenate([inds for (inds, _) in fragments])
     vals = np.concatenate([vals for (_, vals) in fragments])
     size = index_range[0].stop - index_range[0].start
-    return InnerVector(gb.Vector.from_values(inds, vals, size=size, dtype=gb_dtype))
+    return InnerVector(gb.Vector.from_coo(inds, vals, size=size, dtype=gb_dtype))
 
 
 def _pick1D(indices, values, index_range):
@@ -802,8 +802,8 @@ class VectorTupleExtractor:
 
 
 class TupleExtractor:
-    def __init__(self, grblas_inner_vector, index_offset, gb_dtype=None):
-        self.indices, self.values = grblas_inner_vector.value.to_values(gb_dtype)
+    def __init__(self, graphblas_inner_vector, index_offset, gb_dtype=None):
+        self.indices, self.values = graphblas_inner_vector.value.to_values(gb_dtype)
         self.indices += index_offset[0]
 
 
@@ -813,7 +813,7 @@ def _concat_vector(seq, axis=0):
         raise ValueError(f"Can only concatenate for axis 0.  Got {axis}")
     # return InnerVector(gb.ss.concat([item.value for item in seq]))  # TODO: grblas >=1.3.15
     size = sum(x.size for x in seq)
-    value = gb.Vector.new(seq[0].value.dtype, size)
+    value = gb.Vector(seq[0].value.dtype, size)
     start = end = 0
     for x in seq:
         end += x.size
@@ -822,5 +822,5 @@ def _concat_vector(seq, axis=0):
     return InnerVector(value)
 
 
-gb.utils._output_types[Vector] = gb.Vector
+gb.core.utils._output_types[Vector] = gb.Vector
 from .matrix import InnerMatrix  # noqa isort:skip

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,6 @@ setup(
     packages=["dask_grblas"],
     license="Apache License 2.0",
     setup_requires=[],
-    install_requires=["grblas >= 1.3.15", "dask[array]"],
+    install_requires=["python-graphblas >= 2022.11.0", "dask[array]"],
     tests_require=["pytest"],
 )

--- a/tests/from_grblas/test_matrix.py
+++ b/tests/from_grblas/test_matrix.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
-from grblas import binary, dtypes, monoid, semiring, unary
-from grblas.exceptions import DimensionMismatch, IndexOutOfBound, OutputNotEmpty
+from graphblas import binary, dtypes, monoid, semiring, unary
+from graphblas.exceptions import DimensionMismatch, IndexOutOfBound, OutputNotEmpty
 
 from dask_grblas import Matrix, Scalar, Vector
 import dask.array as da

--- a/tests/from_grblas/test_resolving.py
+++ b/tests/from_grblas/test_resolving.py
@@ -1,5 +1,5 @@
 import pytest
-from grblas import binary, dtypes, unary
+from graphblas import binary, dtypes, unary
 
 from dask_grblas import Matrix, Vector
 from dask_grblas.expr import Updater

--- a/tests/from_grblas/test_scalar.py
+++ b/tests/from_grblas/test_scalar.py
@@ -1,5 +1,5 @@
 import pytest
-from grblas import dtypes
+from graphblas import dtypes
 
 from dask_grblas import Scalar
 

--- a/tests/from_grblas/test_vector.py
+++ b/tests/from_grblas/test_vector.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
-from grblas import binary, dtypes, monoid, semiring, unary
-from grblas.exceptions import IndexOutOfBound, OutputNotEmpty
+from graphblas import binary, dtypes, monoid, semiring, unary
+from graphblas.exceptions import IndexOutOfBound, OutputNotEmpty
 
 from dask_grblas import Matrix, Scalar, Vector
 import dask.array as da

--- a/tests/from_grblas2/copytests.py
+++ b/tests/from_grblas2/copytests.py
@@ -1,7 +1,7 @@
 import os
 import subprocess
 
-import grblas.tests as gb_tests
+import graphblas.tests as gb_tests
 
 XFAIL_TESTS = {
     "test_matrix.py": {
@@ -75,7 +75,7 @@ XFAIL_TESTS = {
         "test_update": "Needs investigated",
         "test_expr_is_like_scalar": "Needs investigated",
         "test_ndim": "Needs investigated",
-        "test_cscalar": "Should work in upcoming grblas release",
+        "test_cscalar": "Should work in upcoming graphblas release",
     },
     "test_vector.py": {
         "test_resize": "Needs investigated",
@@ -135,9 +135,9 @@ def main():
                 is_strict = filename not in NOT_STRICT or key not in NOT_STRICT[filename]
                 return f"@pytest.mark.xfail({msg!r}, strict={is_strict})\n{line}"
             if (
-                line.startswith("from grblas import ")
+                line.startswith("from graphblas import ")
                 and ("Matrix" in line or "Vector" in line or "Scalar" in line)
-                or line.startswith("from grblas.expr import Updater")
+                or line.startswith("from graphblas.expr import Updater")
             ):
                 return line[: len("from ")] + "dask_" + line[len("from ") :]
             return line

--- a/tests/from_grblas2/test_op.py
+++ b/tests/from_grblas2/test_op.py
@@ -1,11 +1,12 @@
 import itertools
 
-import grblas as gb
+import graphblas as gb
 import numpy as np
 import pytest
-from grblas import agg, binary, dtypes, lib, monoid, op, operator, semiring, unary
-from grblas.exceptions import DomainMismatch, UdfParseError
-from grblas.operator import BinaryOp, Monoid, Semiring, UnaryOp, get_semiring
+from graphblas import agg, binary, dtypes, monoid, op, semiring, unary
+from graphblas.exceptions import DomainMismatch, UdfParseError
+from graphblas.core import lib, operator
+from graphblas.core.operator import BinaryOp, Monoid, Semiring, UnaryOp, get_semiring
 
 from dask_grblas import Matrix, Vector  # isort:skip
 
@@ -589,7 +590,7 @@ def test_nested_names():
 
     UnaryOp.register_new("incrementers.plus_four", plus_four)
     assert hasattr(unary.incrementers, "plus_four")
-    assert hasattr(op.incrementers, "plus_four")  # Also save it to `grblas.op`!
+    assert hasattr(op.incrementers, "plus_four")  # Also save it to `graphblas.op`!
     v << v.apply(unary.incrementers.plus_four)  # this is in addition to the plus_three earlier
     result2 = Vector.from_values([0, 1, 3], [8, 9, 3], dtype=dtypes.INT32)
     assert v.isequal(result2), v
@@ -620,7 +621,7 @@ def test_op_namespace():
     assert len(dir(op.numpy)) > 500
 
     with pytest.raises(
-        AttributeError, match="module 'grblas.op.numpy' has no attribute 'bad_attr'"
+        AttributeError, match="module 'graphblas.op.numpy' has no attribute 'bad_attr'"
     ):
         op.numpy.bad_attr
 

--- a/tests/from_grblas2/test_resolving.py
+++ b/tests/from_grblas2/test_resolving.py
@@ -1,6 +1,6 @@
 import numpy as np
 import pytest
-from grblas import binary, dtypes, replace, unary
+from graphblas import binary, dtypes, replace, unary
 
 from dask_grblas.expr import Updater
 

--- a/tests/from_grblas2/test_scalar.py
+++ b/tests/from_grblas2/test_scalar.py
@@ -4,8 +4,8 @@ import weakref
 
 import numpy as np
 import pytest
-from grblas import binary, dtypes, replace
-from grblas.scalar import _CScalar
+from graphblas import binary, dtypes, replace
+from graphblas.core.scalar import Scalar
 
 from .conftest import autocompute, compute
 
@@ -214,12 +214,12 @@ def test_not_hashable(s):
         hash(s)
 
 
-@pytest.mark.xfail("'Should work in upcoming grblas release'", strict=False)
+@pytest.mark.xfail("'Should work in upcoming graphblas release'", strict=False)
 def test_cscalar():
-    c1 = _CScalar(Scalar.from_value(5))
-    assert c1 == _CScalar(Scalar.from_value(5))
+    c1 = Scalar.from_value(5, is_cscalar=True)
+    assert c1 == Scalar.from_value(5, is_cscalar=True)
     assert c1 == 5
-    assert c1 != _CScalar(Scalar.from_value(6))
+    assert c1 != Scalar.from_value(6, is_cscalar=True)
     assert c1 != 6
     assert repr(c1) == "5"
     assert c1._repr_html_() == c1.scalar._repr_html_()

--- a/tests/from_grblas2/test_vector.py
+++ b/tests/from_grblas2/test_vector.py
@@ -5,11 +5,11 @@ import sys
 import weakref
 
 import dask_grblas
-import grblas
+import graphblas
 import numpy as np
 import pytest
-from grblas import agg, binary, dtypes, monoid, semiring, unary
-from grblas.exceptions import (
+from graphblas import agg, binary, dtypes, monoid, semiring, unary
+from graphblas.exceptions import (
     DimensionMismatch,
     IndexOutOfBound,
     InvalidValue,
@@ -129,16 +129,16 @@ def test_from_values_scalar():
     assert u.size == 4
     assert u.nvals == 3
     assert u.dtype == dtypes.INT64
-    if hasattr(u, "ss"):  # pragma: no branch
-        assert u.ss.is_iso
+    # if hasattr(u, "ss"):  # pragma: no branch
+    #     assert u.ss.is_iso
     assert u.reduce(monoid.any).new() == 7
 
     # ignore duplicate indices; iso trumps duplicates!
     u = Vector.from_values([0, 1, 1, 3], 7)
     assert u.size == 4
     assert u.nvals == 3
-    if hasattr(u, "ss"):  # pragma: no branch
-        assert u.ss.is_iso
+    # if hasattr(u, "ss"):  # pragma: no branch
+    #     assert u.ss.is_iso
     assert u.reduce(monoid.any).new() == 7
     with pytest.raises(ValueError, match="dup_op must be None"):
         Vector.from_values([0, 1, 1, 3], 7, dup_op=binary.plus)
@@ -876,7 +876,7 @@ def test_del(capsys):
     # v has `gb_obj` of NULL
     v = Vector.from_values([0, 1], [0, 1])
     gb_obj = v.gb_obj
-    v.gb_obj = grblas.ffi.NULL
+    v.gb_obj = graphblas.ffi.NULL
     del v
     # let's clean up so we don't have a memory leak
     v2 = Vector.__new__(Vector)
@@ -1167,7 +1167,7 @@ def test_vector_index_with_scalar():
         w = v[[s1, s0]].new()
         assert w.isequal(expected)
     for dtype in (
-        ["bool", "fp32", "fp64"] + ["fc32", "fc64"] if grblas.dtypes._supports_complex else []
+        ["bool", "fp32", "fp64"] + ["fc32", "fc64"] if graphblas.dtypes._supports_complex else []
     ):
         s = Scalar.from_value(1, dtype=dtype)
         with pytest.raises(TypeError, match="An integer is required for indexing"):
@@ -1561,7 +1561,7 @@ def test_concat(v):
     expected = Vector.new(v.dtype, size=2 * v.size)
     expected[: v.size] = v
     expected[v.size :] = v
-    w1 = grblas.ss.concat([v, v])
+    w1 = graphblas.ss.concat([v, v])
     assert w1.isequal(expected)
     w2 = Vector.new(v.dtype, size=2 * v.size)
     w2.ss.concat([v, v])

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -2,9 +2,9 @@ import inspect
 import itertools
 from functools import partial
 
-import grblas as gb
+import graphblas as gb
 import pytest
-from grblas import dtypes
+from graphblas import dtypes
 from pytest import raises
 
 import dask.array as da
@@ -22,7 +22,7 @@ def inv_if(mask, is_inv=False):
 def adapt(index, x):
     return (
         index.compute()
-        if isinstance(x, gb.base.BaseType) and type(index) is da.core.Array
+        if isinstance(x, gb.core.base.BaseType) and type(index) is da.core.Array
         else index
     )
 
@@ -366,13 +366,13 @@ def test_from_MMfile():
     filename = str(path / "notebooks" / "coo_matrix_A.mtx")
 
     M = mmread(filename)
-    M = gb.io.from_scipy_sparse_matrix(M)
+    M = gb.io.from_scipy_sparse(M)
     dM = dgb.Matrix.from_MMfile(filename)
     compare(lambda x: x, M, dM)
 
     filename = str(path / "notebooks" / "dense_matrix_A.mtx")
     M = mmread(filename)
-    M = gb.io.from_scipy_sparse_matrix(coo_matrix(M))
+    M = gb.io.from_scipy_sparse(coo_matrix(M))
     dM = dgb.Matrix.from_MMfile(filename)
     compare(lambda x: x, M, dM)
 

--- a/tests/test_scalar.py
+++ b/tests/test_scalar.py
@@ -1,8 +1,8 @@
 import inspect
 
-import grblas as gb
+import graphblas as gb
 import pytest
-from grblas import dtypes
+from graphblas import dtypes
 from pytest import raises
 
 import dask_grblas as dgb

--- a/tests/test_vector.py
+++ b/tests/test_vector.py
@@ -1,8 +1,8 @@
 import inspect
 
-import grblas as gb
+import graphblas as gb
 import pytest
-from grblas import dtypes
+from graphblas import dtypes
 from pytest import raises
 import dask.array as da
 
@@ -1058,7 +1058,7 @@ def test_subassign(vs, ws, vms, sms):
         def f2(x, y):
             ind = (
                 index.compute()
-                if isinstance(x, gb.base.BaseType) and type(index) is da.core.Array
+                if isinstance(x, gb.core.base.BaseType) and type(index) is da.core.Array
                 else index
             )
             x[ind]() << y
@@ -1067,7 +1067,7 @@ def test_subassign(vs, ws, vms, sms):
         def g1(m, x, y):
             ind = (
                 index.compute()
-                if isinstance(x, gb.base.BaseType) and type(index) is da.core.Array
+                if isinstance(x, gb.core.base.BaseType) and type(index) is da.core.Array
                 else index
             )
             x[ind](mask=m) << y
@@ -1076,7 +1076,7 @@ def test_subassign(vs, ws, vms, sms):
         def g2(x, y):
             ind = (
                 index.compute()
-                if isinstance(x, gb.base.BaseType) and type(index) is da.core.Array
+                if isinstance(x, gb.core.base.BaseType) and type(index) is da.core.Array
                 else index
             )
             x[ind](accum=gb.binary.plus) << y
@@ -1085,7 +1085,7 @@ def test_subassign(vs, ws, vms, sms):
         def g3(x, y):
             ind = (
                 index.compute()
-                if isinstance(x, gb.base.BaseType) and type(index) is da.core.Array
+                if isinstance(x, gb.core.base.BaseType) and type(index) is da.core.Array
                 else index
             )
             x[ind](replace=True) << y
@@ -1094,7 +1094,7 @@ def test_subassign(vs, ws, vms, sms):
         def g4(x, y):
             ind = (
                 index.compute()
-                if isinstance(x, gb.base.BaseType) and type(index) is da.core.Array
+                if isinstance(x, gb.core.base.BaseType) and type(index) is da.core.Array
                 else index
             )
             x[ind](replace=False) << y
@@ -1103,7 +1103,7 @@ def test_subassign(vs, ws, vms, sms):
         def h1(x, y):
             ind = (
                 index.compute()
-                if isinstance(x, gb.base.BaseType) and type(index) is da.core.Array
+                if isinstance(x, gb.core.base.BaseType) and type(index) is da.core.Array
                 else index
             )
             x[ind](accum=gb.binary.plus, replace=True) << y
@@ -1112,7 +1112,7 @@ def test_subassign(vs, ws, vms, sms):
         def h2(x, y):
             ind = (
                 index.compute()
-                if isinstance(x, gb.base.BaseType) and type(index) is da.core.Array
+                if isinstance(x, gb.core.base.BaseType) and type(index) is da.core.Array
                 else index
             )
             x[ind](accum=gb.binary.plus, replace=False) << y
@@ -1121,7 +1121,7 @@ def test_subassign(vs, ws, vms, sms):
         def h3(m, x, y):
             ind = (
                 index.compute()
-                if isinstance(x, gb.base.BaseType) and type(index) is da.core.Array
+                if isinstance(x, gb.core.base.BaseType) and type(index) is da.core.Array
                 else index
             )
             x[ind](mask=m, replace=test_replace_true) << y
@@ -1130,7 +1130,7 @@ def test_subassign(vs, ws, vms, sms):
         def h4(m, x, y):
             ind = (
                 index.compute()
-                if isinstance(x, gb.base.BaseType) and type(index) is da.core.Array
+                if isinstance(x, gb.core.base.BaseType) and type(index) is da.core.Array
                 else index
             )
             x[ind](mask=m, replace=False) << y
@@ -1139,7 +1139,7 @@ def test_subassign(vs, ws, vms, sms):
         def h5(m, x, y):
             ind = (
                 index.compute()
-                if isinstance(x, gb.base.BaseType) and type(index) is da.core.Array
+                if isinstance(x, gb.core.base.BaseType) and type(index) is da.core.Array
                 else index
             )
             x[ind](mask=m, accum=gb.binary.plus) << y
@@ -1148,7 +1148,7 @@ def test_subassign(vs, ws, vms, sms):
         def i1(m, x, y):
             ind = (
                 index.compute()
-                if isinstance(x, gb.base.BaseType) and type(index) is da.core.Array
+                if isinstance(x, gb.core.base.BaseType) and type(index) is da.core.Array
                 else index
             )
             x[ind](mask=m, accum=gb.binary.plus, replace=test_replace_true) << y
@@ -1157,7 +1157,7 @@ def test_subassign(vs, ws, vms, sms):
         def i2(m, x, y):
             ind = (
                 index.compute()
-                if isinstance(x, gb.base.BaseType) and type(index) is da.core.Array
+                if isinstance(x, gb.core.base.BaseType) and type(index) is da.core.Array
                 else index
             )
             x[ind](mask=m, accum=gb.binary.plus, replace=False) << y
@@ -1340,7 +1340,7 @@ def test_assign(vs, ws, vms, sms):
         def f1(x, y):
             ind = (
                 index.compute()
-                if isinstance(x, gb.base.BaseType) and type(index) is da.core.Array
+                if isinstance(x, gb.core.base.BaseType) and type(index) is da.core.Array
                 else index
             )
             x[ind] << y
@@ -1349,7 +1349,7 @@ def test_assign(vs, ws, vms, sms):
         def f2(x, y):
             ind = (
                 index.compute()
-                if isinstance(x, gb.base.BaseType) and type(index) is da.core.Array
+                if isinstance(x, gb.core.base.BaseType) and type(index) is da.core.Array
                 else index
             )
             x()[ind] << y
@@ -1358,7 +1358,7 @@ def test_assign(vs, ws, vms, sms):
         def g1(m, x, y):
             ind = (
                 index.compute()
-                if isinstance(x, gb.base.BaseType) and type(index) is da.core.Array
+                if isinstance(x, gb.core.base.BaseType) and type(index) is da.core.Array
                 else index
             )
             x(mask=m)[ind] << y
@@ -1367,7 +1367,7 @@ def test_assign(vs, ws, vms, sms):
         def g2(x, y):
             ind = (
                 index.compute()
-                if isinstance(x, gb.base.BaseType) and type(index) is da.core.Array
+                if isinstance(x, gb.core.base.BaseType) and type(index) is da.core.Array
                 else index
             )
             x(accum=gb.binary.plus)[ind] << y
@@ -1376,7 +1376,7 @@ def test_assign(vs, ws, vms, sms):
         def g3(x, y):
             ind = (
                 index.compute()
-                if isinstance(x, gb.base.BaseType) and type(index) is da.core.Array
+                if isinstance(x, gb.core.base.BaseType) and type(index) is da.core.Array
                 else index
             )
             x(replace=True)[ind] << y
@@ -1385,7 +1385,7 @@ def test_assign(vs, ws, vms, sms):
         def g4(x, y):
             ind = (
                 index.compute()
-                if isinstance(x, gb.base.BaseType) and type(index) is da.core.Array
+                if isinstance(x, gb.core.base.BaseType) and type(index) is da.core.Array
                 else index
             )
             x(replace=False)[ind] << y
@@ -1394,7 +1394,7 @@ def test_assign(vs, ws, vms, sms):
         def h1(x, y):
             ind = (
                 index.compute()
-                if isinstance(x, gb.base.BaseType) and type(index) is da.core.Array
+                if isinstance(x, gb.core.base.BaseType) and type(index) is da.core.Array
                 else index
             )
             x(accum=gb.binary.plus, replace=True)[ind] << y
@@ -1403,7 +1403,7 @@ def test_assign(vs, ws, vms, sms):
         def h2(x, y):
             ind = (
                 index.compute()
-                if isinstance(x, gb.base.BaseType) and type(index) is da.core.Array
+                if isinstance(x, gb.core.base.BaseType) and type(index) is da.core.Array
                 else index
             )
             x(accum=gb.binary.plus, replace=False)[ind] << y
@@ -1412,7 +1412,7 @@ def test_assign(vs, ws, vms, sms):
         def h3(m, x, y):
             ind = (
                 index.compute()
-                if isinstance(x, gb.base.BaseType) and type(index) is da.core.Array
+                if isinstance(x, gb.core.base.BaseType) and type(index) is da.core.Array
                 else index
             )
             x(mask=m, replace=test_replace_true)[ind] << y
@@ -1421,7 +1421,7 @@ def test_assign(vs, ws, vms, sms):
         def h4(m, x, y):
             ind = (
                 index.compute()
-                if isinstance(x, gb.base.BaseType) and type(index) is da.core.Array
+                if isinstance(x, gb.core.base.BaseType) and type(index) is da.core.Array
                 else index
             )
             x(mask=m, replace=False)[ind] << y
@@ -1430,7 +1430,7 @@ def test_assign(vs, ws, vms, sms):
         def h5(m, x, y):
             ind = (
                 index.compute()
-                if isinstance(x, gb.base.BaseType) and type(index) is da.core.Array
+                if isinstance(x, gb.core.base.BaseType) and type(index) is da.core.Array
                 else index
             )
             x(mask=m, accum=gb.binary.plus)[ind] << y
@@ -1439,7 +1439,7 @@ def test_assign(vs, ws, vms, sms):
         def i1(m, x, y):
             ind = (
                 index.compute()
-                if isinstance(x, gb.base.BaseType) and type(index) is da.core.Array
+                if isinstance(x, gb.core.base.BaseType) and type(index) is da.core.Array
                 else index
             )
             x(mask=m, accum=gb.binary.plus, replace=test_replace_true)[ind] << y
@@ -1448,7 +1448,7 @@ def test_assign(vs, ws, vms, sms):
         def i2(m, x, y):
             ind = (
                 index.compute()
-                if isinstance(x, gb.base.BaseType) and type(index) is da.core.Array
+                if isinstance(x, gb.core.base.BaseType) and type(index) is da.core.Array
                 else index
             )
             x(mask=m, accum=gb.binary.plus, replace=False)[ind] << y
@@ -1630,7 +1630,7 @@ def test_reduce_assign(vs, ws, vms, sms):
     ]:
 
         def f1(x, y):
-            if isinstance(x, gb.base.BaseType):
+            if isinstance(x, gb.core.base.BaseType):
                 ind = index.compute() if type(index) is da.core.Array else index
                 x[ind] << y
             else:
@@ -1639,7 +1639,7 @@ def test_reduce_assign(vs, ws, vms, sms):
             return x
 
         def g1(m, x, y):
-            if isinstance(x, gb.base.BaseType):
+            if isinstance(x, gb.core.base.BaseType):
                 ind = index.compute() if type(index) is da.core.Array else index
                 x(mask=m)[ind] << y
             else:
@@ -1648,7 +1648,7 @@ def test_reduce_assign(vs, ws, vms, sms):
             return x
 
         def g2(x, y):
-            if isinstance(x, gb.base.BaseType):
+            if isinstance(x, gb.core.base.BaseType):
                 ind = index.compute() if type(index) is da.core.Array else index
                 x(accum=gb.binary.plus)[ind] << y
             else:
@@ -1657,7 +1657,7 @@ def test_reduce_assign(vs, ws, vms, sms):
             return x
 
         def g3(x, y):
-            if isinstance(x, gb.base.BaseType):
+            if isinstance(x, gb.core.base.BaseType):
                 ind = index.compute() if type(index) is da.core.Array else index
                 x(replace=True)[ind] << y
             else:
@@ -1666,7 +1666,7 @@ def test_reduce_assign(vs, ws, vms, sms):
             return x
 
         def g4(x, y):
-            if isinstance(x, gb.base.BaseType):
+            if isinstance(x, gb.core.base.BaseType):
                 ind = index.compute() if type(index) is da.core.Array else index
                 x(replace=False)[ind] << y
             else:
@@ -1675,7 +1675,7 @@ def test_reduce_assign(vs, ws, vms, sms):
             return x
 
         def h1(x, y):
-            if isinstance(x, gb.base.BaseType):
+            if isinstance(x, gb.core.base.BaseType):
                 ind = index.compute() if type(index) is da.core.Array else index
                 x(accum=gb.binary.plus, replace=True)[ind] << y
             else:
@@ -1684,7 +1684,7 @@ def test_reduce_assign(vs, ws, vms, sms):
             return x
 
         def h2(x, y):
-            if isinstance(x, gb.base.BaseType):
+            if isinstance(x, gb.core.base.BaseType):
                 ind = index.compute() if type(index) is da.core.Array else index
                 x(accum=gb.binary.plus, replace=False)[ind] << y
             else:
@@ -1695,7 +1695,7 @@ def test_reduce_assign(vs, ws, vms, sms):
             return x
 
         def h3(m, x, y):
-            if isinstance(x, gb.base.BaseType):
+            if isinstance(x, gb.core.base.BaseType):
                 ind = index.compute() if type(index) is da.core.Array else index
                 x(mask=m, replace=True)[ind] << y
             else:
@@ -1704,7 +1704,7 @@ def test_reduce_assign(vs, ws, vms, sms):
             return x
 
         def h4(m, x, y):
-            if isinstance(x, gb.base.BaseType):
+            if isinstance(x, gb.core.base.BaseType):
                 ind = index.compute() if type(index) is da.core.Array else index
                 x(mask=m, replace=False)[ind] << y
             else:
@@ -1713,7 +1713,7 @@ def test_reduce_assign(vs, ws, vms, sms):
             return x
 
         def h5(m, x, y):
-            if isinstance(x, gb.base.BaseType):
+            if isinstance(x, gb.core.base.BaseType):
                 ind = index.compute() if type(index) is da.core.Array else index
                 x(mask=m, accum=gb.binary.plus)[ind] << y
             else:
@@ -1722,7 +1722,7 @@ def test_reduce_assign(vs, ws, vms, sms):
             return x
 
         def i1(m, x, y):
-            if isinstance(x, gb.base.BaseType):
+            if isinstance(x, gb.core.base.BaseType):
                 ind = index.compute() if type(index) is da.core.Array else index
                 x(mask=m, accum=gb.binary.plus, replace=True)[ind] << y
             else:
@@ -1733,7 +1733,7 @@ def test_reduce_assign(vs, ws, vms, sms):
             return x
 
         def i2(m, x, y):
-            if isinstance(x, gb.base.BaseType):
+            if isinstance(x, gb.core.base.BaseType):
                 ind = index.compute() if type(index) is da.core.Array else index
                 x(mask=m, accum=gb.binary.plus, replace=False)[ind] << y
             else:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-import grblas as gb
+import graphblas as gb
 
 import dask_grblas as dgb
 
@@ -41,7 +41,7 @@ def compare(func, gb_args, dgb_args, gb_kwargs={}, dgb_kwargs={}, *, compute=Non
                 raise
             dgb_result = exc
     assert type(gb_result) == type(dgb_result), f"{type(gb_result)} - {type(dgb_result)}"
-    if isinstance(gb_result, gb.base.BaseType):
+    if isinstance(gb_result, gb.core.base.BaseType):
         assert gb_result.dtype == dgb_result.dtype, f"{gb_result.dtype} - {dgb_result.dtype}"
         if not gb_result.isequal(dgb_result, check_dtype=True):
             print(gb_result)


### PR DESCRIPTION
Hopefully this doesn't duplicate work already done by Henry. This was a quick and dirty attempt to make dask-grblas work with the latest version of python-graphblas.

Not all tests pass, but most do.

More work is still needed to rename dask-grblas to dask-graphblas and bring the API up to the same state as python-graphblas, as that has been a fast-moving target over the past year.


- import grblas is now import graphblas
- python-graphblas has been refactored to clean up the main namespace