### PR TITLE
Update black to a more recent version

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -46,7 +46,7 @@ jobs:
           python-version: 3.9
       - name: Update env
         run: |
-          conda install -q -c conda-forge 'graphblas>=6.1' grblas dask pytest 'black=21.11b1' flake8 coverage coveralls scipy
+          conda install -q -c conda-forge 'graphblas>=6.1' grblas dask pytest 'black=22.10' flake8 coverage coveralls scipy
           pip install -e .
       - name: Lint with Black
         run: |

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,9 +7,12 @@ exclude =
     tests/,
     versioneer.py,
 ignore =
-    E203,   # whitespace before ':'
-    E231,   # Multiple spaces around ","
-    W503,   # line break before binary operator
+    # whitespace before ':'
+    E203,
+    # Multiple spaces around ","
+    E231,
+    # line break before binary operator
+    W503,
 
 [tool:pytest]
 markers:


### PR DESCRIPTION
This appears to be a compatibility issue of black and click, see https://stackoverflow.com/a/71674345/10693596

Another issue raised is inline comments in .cfg for flake8 (apparently not allowed any more).